### PR TITLE
display a 404 page and set up redirects

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
 import { AboutComponent } from './components/about/about.component';
+import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 
 
 export const routes: Routes = [
@@ -19,5 +20,14 @@ export const routes: Routes = [
     {
         path:'contact',
         component:AboutComponent
+    },
+    {
+        path:'',
+        redirectTo:'/home',
+        pathMatch: 'full'
+    },
+    {
+        path: '**',
+        component:PageNotFoundComponent
     }
 ];

--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -1,11 +1,3 @@
 .container{
-    background-color: #007bff;
-    max-width: 600px;
-    margin: auto;
-    padding: 1em;
-    background: #26A69A;
-    display: flex;
-    flex-flow: row;
-    flex-wrap: wrap;
-    justify-content: center;
+   
 }

--- a/src/app/components/page-not-found/page-not-found.component.html
+++ b/src/app/components/page-not-found/page-not-found.component.html
@@ -1,0 +1,2 @@
+<h2>Page Not Found</h2>
+<p>The page you're looking for was not found!</p>

--- a/src/app/components/page-not-found/page-not-found.component.spec.ts
+++ b/src/app/components/page-not-found/page-not-found.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PageNotFoundComponent } from './page-not-found.component';
+
+describe('PageNotFoundComponent', () => {
+  let component: PageNotFoundComponent;
+  let fixture: ComponentFixture<PageNotFoundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageNotFoundComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(PageNotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/page-not-found/page-not-found.component.ts
+++ b/src/app/components/page-not-found/page-not-found.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-page-not-found',
+  standalone: true,
+  imports: [],
+  templateUrl: './page-not-found.component.html',
+  styleUrl: './page-not-found.component.scss'
+})
+export class PageNotFoundComponent {
+
+}


### PR DESCRIPTION
- To display a 404 page, set up a wildcard route with the component property set to the PageNotFound component for 404 page.The router selects this route if the request URL doesn't match any of the paths earlier in the list and sends the user to the PageNotFoundComponent
- To set up a redirect, configure a route with the HomeComponent, and a pathMatch value that tells the router how to match the URL